### PR TITLE
feat: add tap to dismiss functionality for toasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ tasks.md
 *tsbuildinfo
 
 .vite
+
+.claude/settings.local.json

--- a/src/contexts/ToastContext.test.tsx
+++ b/src/contexts/ToastContext.test.tsx
@@ -342,6 +342,62 @@ describe('ToastContext', () => {
         expect(hiddenContainer.querySelector('.animate-leave')).toBeInTheDocument();
       }
     });
+
+    it('should dismiss toast when clicked', async () => {
+      const user = userEvent.setup();
+      let customCallback: ((props: { id: string; visible: boolean }) => React.ReactElement) | undefined;
+      
+      (toast.custom as jest.Mock).mockImplementation((callback) => {
+        customCallback = callback;
+        return 'toast-id';
+      });
+      
+      render(
+        <TestWrapper>
+          <TestToastComponent />
+        </TestWrapper>
+      );
+
+      await user.click(screen.getByRole('button', { name: /show success/i }));
+
+      // Render the toast and test dismiss functionality
+      if (customCallback) {
+        const { container } = render(customCallback({ id: 'test-id', visible: true }));
+        const toastDiv = container.querySelector('div[onclick]');
+        
+        if (toastDiv) {
+          await user.click(toastDiv);
+          expect(toast.dismiss).toHaveBeenCalledWith('test-id');
+        }
+      }
+    });
+
+    it('should dismiss toast when X button is clicked', async () => {
+      const user = userEvent.setup();
+      let customCallback: ((props: { id: string; visible: boolean }) => React.ReactElement) | undefined;
+      
+      (toast.custom as jest.Mock).mockImplementation((callback) => {
+        customCallback = callback;
+        return 'toast-id';
+      });
+      
+      render(
+        <TestWrapper>
+          <TestToastComponent />
+        </TestWrapper>
+      );
+
+      await user.click(screen.getByRole('button', { name: /show info/i }));
+
+      // Render the toast and test X button dismiss
+      if (customCallback) {
+        const { getByLabelText } = render(customCallback({ id: 'test-id', visible: true }));
+        const dismissButton = getByLabelText('Dismiss notification');
+        
+        await user.click(dismissButton);
+        expect(toast.dismiss).toHaveBeenCalledWith('test-id');
+      }
+    });
   });
 
   describe('Error Handling', () => {

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -17,9 +17,12 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
   const showToast = (type: ToastType, title: string, message?: string, duration?: number): string => {
     const toastId = toast.custom(
       (t) => (
-        <div className={`${
-          t.visible ? 'animate-enter' : 'animate-leave'
-        } max-w-md w-full bg-white dark:bg-retro-900 shadow-lg rounded-lg pointer-events-auto flex ring-1 ring-black ring-opacity-5 dark:ring-white dark:ring-opacity-20`}>
+        <div 
+          className={`${
+            t.visible ? 'animate-enter' : 'animate-leave pointer-events-none'
+          } max-w-md w-full bg-white dark:bg-retro-900 shadow-lg rounded-lg pointer-events-auto flex ring-1 ring-black ring-opacity-5 dark:ring-white dark:ring-opacity-20 cursor-pointer`}
+          onClick={() => toast.dismiss(t.id)}
+        >
           <div className="flex-1 w-0 p-4">
             <div className="flex items-start space-x-3">
               {type === 'success' && <Check className="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />}
@@ -31,6 +34,18 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
                 {message && <p className="text-sm text-retro-600 dark:text-retro-400 mt-1">{message}</p>}
               </div>
             </div>
+          </div>
+          <div className="flex border-l border-retro-200 dark:border-retro-700">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                toast.dismiss(t.id);
+              }}
+              className="w-full p-4 flex items-center justify-center hover:bg-retro-50 dark:hover:bg-retro-800 rounded-r-lg transition-colors duration-150"
+              aria-label="Dismiss notification"
+            >
+              <X className="w-5 h-5 text-retro-400 dark:text-retro-500" />
+            </button>
           </div>
         </div>
       ),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,14 +26,24 @@ export default {
       fontFamily: {
         'mono': ['Cascadia Code', 'Fira Code', 'Monaco', 'Consolas', 'monospace'],
       },
-      animation: {
-        'slide-up': 'slideUp 0.3s ease-out',
-      },
       keyframes: {
         slideUp: {
           '0%': { transform: 'translateY(100%)' },
           '100%': { transform: 'translateY(0)' },
         },
+        enter: {
+          '0%': { transform: 'translateX(100%)', opacity: 0 },
+          '100%': { transform: 'translateX(0)', opacity: 1 },
+        },
+        leave: {
+          '0%': { transform: 'translateX(0)', opacity: 1 },
+          '100%': { transform: 'translateX(100%)', opacity: 0 },
+        },
+      },
+      animation: {
+        'slide-up': 'slideUp 0.3s ease-out',
+        enter: 'enter 0.3s ease-out',
+        leave: 'leave 0.3s ease-in forwards',
       },
     },
   },


### PR DESCRIPTION
- Added click handler to dismiss toasts when clicked anywhere on the toast
- Added dedicated X button for explicit dismiss action
- Added smooth enter/leave animations for toast appearance/disappearance
- Updated tests to verify dismiss functionality works correctly
- Closes #36

🤖 Generated with [Claude Code](https://claude.ai/code)