### PR TITLE
fix: remove toast notification when navigating to current position

### DIFF
--- a/src/containers/GuideReaderContainer.tsx
+++ b/src/containers/GuideReaderContainer.tsx
@@ -178,7 +178,6 @@ export const GuideReaderContainer: React.FC<GuideReaderContainerProps> = ({ guid
     try {
       const currentPosBookmark = await db.getCurrentPositionBookmark(guide.id);
       if (currentPosBookmark) {
-        showToast('success', 'Jumped to current position', `Line ${currentPosBookmark.line}`);
         return currentPosBookmark.line;
       } else {
         showToast('info', 'No current position saved', 'Tap any line to set your current reading position');


### PR DESCRIPTION
- Removed success toast from handleJumpToCurrentPosition function
- Navigation still works and scrolls to the position
- Fixes #39: toast was unnecessary as the scroll action provides sufficient feedback