### PR TITLE
fix: resolve guide text disappearing when zooming

### DIFF
--- a/src/components/GuideReaderView.tsx
+++ b/src/components/GuideReaderView.tsx
@@ -98,7 +98,7 @@ const GuideReaderViewComponent: React.FC<GuideReaderViewProps> = ({
     
     const container = containerRef.current;
     const { scrollTop, clientHeight } = container;
-    const lineHeight = lineHeightRef.current;
+    const lineHeight = lineHeightRef.current * zoomLevel;
     
     const startIndex = Math.max(0, Math.floor(scrollTop / lineHeight) - OVERSCAN_COUNT * 10);
     const endIndex = Math.min(totalLines, Math.ceil((scrollTop + clientHeight) / lineHeight) + OVERSCAN_COUNT * 10);
@@ -120,18 +120,18 @@ const GuideReaderViewComponent: React.FC<GuideReaderViewProps> = ({
         setShowFloatingProgress(false);
       }, 1500);
     }
-  }, [isLoading, totalLines]);
+  }, [isLoading, totalLines, zoomLevel]);
 
   // Scroll to a specific line
   const scrollToLine = useCallback((line: number, behavior: ScrollBehavior = 'smooth') => {
     if (!containerRef.current || !lineHeightRef.current) return;
     
-    const targetScrollTop = (line - 1) * lineHeightRef.current;
+    const targetScrollTop = (line - 1) * lineHeightRef.current * zoomLevel;
     containerRef.current.scrollTo({
       top: targetScrollTop,
       behavior
     });
-  }, []);
+  }, [zoomLevel]);
 
   // Long press handlers
   const handleLongPressStart = useCallback((lineNumber: number) => {
@@ -221,12 +221,12 @@ const GuideReaderViewComponent: React.FC<GuideReaderViewProps> = ({
     }
   };
 
-  // Update line height when font size changes
+  // Update line height when font size or zoom changes
   useEffect(() => {
     lineHeightRef.current = Math.ceil(fontSize * 1.5);
     // Trigger a recalculation of visible range
     updateVisibleRange();
-  }, [fontSize, updateVisibleRange]);
+  }, [fontSize, zoomLevel, updateVisibleRange]);
 
   // Initial scroll to saved position
   useEffect(() => {
@@ -309,13 +309,12 @@ const GuideReaderViewComponent: React.FC<GuideReaderViewProps> = ({
         }}
       >
         <div 
-          className="relative origin-top-left" 
+          className="relative" 
           ref={contentRef} 
           style={{ 
-            height: totalHeight * zoomLevel,
-            transform: `scale(${zoomLevel})`,
-            width: `${100 / zoomLevel}%`,
-            willChange: 'transform'
+            height: totalHeight,
+            zoom: zoomLevel,
+            willChange: 'zoom'
           }}
         >
           <div style={{ 


### PR DESCRIPTION
## Summary
- Fixes issue where guide text would disappear when using zoom controls
- Replaces CSS transform approach with CSS zoom property for better reliability
- Updates scroll and visible range calculations to account for zoom level

## What Changed
- Changed from using `transform: scale()` to `zoom` CSS property in GuideReaderView
- Updated `scrollToLine` function to multiply scroll position by zoom level
- Updated `updateVisibleRange` to account for zoom when calculating visible lines
- Added zoom level to dependency arrays where needed

## Test Plan
- [x] Open a guide
- [x] Tap Settings, tap either `-` or `+` for zoom
- [x] Verify guide text zooms in/out without disappearing
- [x] Verify scrolling works correctly at different zoom levels
- [x] Verify line navigation works correctly when zoomed
- [x] All tests pass (`npm run test`)
- [x] No lint errors (`npm run lint`)
- [x] Build succeeds (`npm run build`)

Fixes #48