### PR TITLE
Remove all keyboard events from the codebase

### DIFF
--- a/src/components/GuideNavigationControls.tsx
+++ b/src/components/GuideNavigationControls.tsx
@@ -46,26 +46,6 @@ export const GuideNavigationControls: React.FC<GuideNavigationControlsProps> = (
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case 'ArrowUp':
-        e.preventDefault();
-        onLineChange(Math.max(MIN_LINE, currentLine - 1));
-        break;
-      case 'ArrowDown':
-        e.preventDefault();
-        onLineChange(Math.min(totalLines, currentLine + 1));
-        break;
-      case 'PageUp':
-        e.preventDefault();
-        onLineChange(Math.max(MIN_LINE, currentLine - 10));
-        break;
-      case 'PageDown':
-        e.preventDefault();
-        onLineChange(Math.min(totalLines, currentLine + 10));
-        break;
-    }
-  };
 
   return (
     <div className="flex flex-col sm:flex-row flex-wrap items-start sm:items-center justify-between gap-4">
@@ -85,7 +65,6 @@ export const GuideNavigationControls: React.FC<GuideNavigationControlsProps> = (
           max={totalLines}
           value={currentLine}
           onChange={handleLineInputChange}
-          onKeyDown={handleKeyDown}
           disabled={isLoading}
           className={clsx(
             'w-20 px-2 py-1 text-sm',

--- a/src/components/UrlImport.tsx
+++ b/src/components/UrlImport.tsx
@@ -10,11 +10,6 @@ interface UrlImportProps {
 export const UrlImport: React.FC<UrlImportProps> = ({ onFetch, loading }) => {
   const [url, setUrl] = useState('');
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await onFetch(url);
-    setUrl('');
-  };
 
   const handleButtonClick = () => {
     if (!url.trim()) return;
@@ -23,12 +18,6 @@ export const UrlImport: React.FC<UrlImportProps> = ({ onFetch, loading }) => {
     onFetch(currentUrl);
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      handleSubmit(e as unknown as React.FormEvent);
-    }
-  };
 
   return (
     <>
@@ -37,7 +26,6 @@ export const UrlImport: React.FC<UrlImportProps> = ({ onFetch, loading }) => {
           type="url" 
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          onKeyPress={handleKeyPress}
           placeholder="Enter guide URL (direct text file)..." 
           className="flex-1 px-3 py-2 border border-retro-300 dark:border-retro-600 rounded-md shadow-sm text-retro-900 dark:text-retro-100 bg-white dark:bg-retro-800 placeholder-retro-400 dark:placeholder-retro-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
           disabled={loading}

--- a/src/containers/AppContentContainer.test.tsx
+++ b/src/containers/AppContentContainer.test.tsx
@@ -246,38 +246,6 @@ describe('AppContentContainer', () => {
     });
   });
 
-  describe('Keyboard Navigation', () => {
-    it('should handle escape key to go back to library', async () => {
-      mockUseApp.mockReturnValue({
-        currentView: 'reader',
-        setCurrentView: mockSetCurrentView,
-        currentGuideId: 'test-guide-1',
-        setCurrentGuideId: mockSetCurrentGuideId,
-        setNavigationTargetLine: mockSetNavigationTargetLine
-      });
-
-      render(<AppContentContainer />);
-      
-      const event = new KeyboardEvent('keydown', { key: 'Escape' });
-      document.dispatchEvent(event);
-      
-      expect(mockSetCurrentView).toHaveBeenCalledWith('library');
-      expect(mockSetCurrentGuideId).toHaveBeenCalledWith(null);
-    });
-
-    it('should not handle escape key when already in library view', () => {
-      // Clear the previous calls
-      jest.clearAllMocks();
-      
-      render(<AppContentContainer />);
-      
-      const event = new KeyboardEvent('keydown', { key: 'Escape' });
-      document.dispatchEvent(event);
-      
-      expect(mockSetCurrentView).not.toHaveBeenCalled();
-      expect(mockSetCurrentGuideId).not.toHaveBeenCalled();
-    });
-  });
 
   describe('URL Handling', () => {
     it('should handle URL with guide ID on mount', () => {

--- a/src/containers/AppContentContainer.tsx
+++ b/src/containers/AppContentContainer.tsx
@@ -42,18 +42,6 @@ export const AppContentContainer: React.FC = () => {
     loadGuide();
   }, [currentGuideId, getGuide, setCurrentGuideId, setCurrentView]);
 
-  // Handle escape key to go back to library
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && currentView !== 'library') {
-        setCurrentView('library');
-        setCurrentGuideId(null);
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [currentView, setCurrentView, setCurrentGuideId]);
 
   // Setup service worker
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Removed all keyboard event handlers from the codebase as requested in #58
- The application is now purely scroll/touch-based

## Changes
- Removed `onKeyPress` handler from `UrlImport` component (previously handled Enter key for form submission)
- Removed `onKeyDown` handler from `GuideNavigationControls` component (previously handled arrow keys and PageUp/PageDown)
- Removed global keyboard event listener from `AppContentContainer` (previously handled Escape key for navigation)
- Removed keyboard navigation tests from `AppContentContainer.test.tsx`

## Test plan
- [x] All tests pass (`npm run test`)
- [x] Lint passes (`npm run lint`)
- [x] Code coverage slightly below 80% threshold due to removed tests (expected)
- [ ] Manual testing: Verify keyboard events no longer work
- [ ] Manual testing: Verify all functionality still accessible via touch/mouse

Fixes #58