### PR TITLE
feat: replace long press with double tap for bookmarks

### DIFF
--- a/src/components/BookmarksEmptyState.test.tsx
+++ b/src/components/BookmarksEmptyState.test.tsx
@@ -12,7 +12,7 @@ describe('BookmarksEmptyState', () => {
   it('should render instruction text', () => {
     render(<BookmarksEmptyState />);
     
-    expect(screen.getByText('Long press on any line to create one')).toBeInTheDocument();
+    expect(screen.getByText('Double tap on any line to create one')).toBeInTheDocument();
   });
 
   it('should render bookmark icon', () => {

--- a/src/components/BookmarksEmptyState.tsx
+++ b/src/components/BookmarksEmptyState.tsx
@@ -6,7 +6,7 @@ export const BookmarksEmptyState: React.FC = () => {
     <div className="text-center py-8 text-retro-600 dark:text-retro-400">
       <BookmarkIcon className="w-12 h-12 mx-auto mb-3 opacity-50" />
       <p className="text-sm">No bookmarks yet</p>
-      <p className="text-xs mt-1">Long press on any line to create one</p>
+      <p className="text-xs mt-1">Double tap on any line to create one</p>
     </div>
   );
 };

--- a/src/components/GuideLineRenderer.test.tsx
+++ b/src/components/GuideLineRenderer.test.tsx
@@ -10,12 +10,9 @@ describe('GuideLineRenderer', () => {
     isBookmarked: false,
     isCurrentPosition: false,
     lineHeight: 24,
+    fontSize: 16,
     searchQuery: '',
-    onMouseDown: jest.fn(),
-    onMouseUp: jest.fn(),
-    onMouseLeave: jest.fn(),
-    onTouchStart: jest.fn(),
-    onTouchEnd: jest.fn()
+    onClick: jest.fn()
   };
 
   beforeEach(() => {
@@ -59,50 +56,32 @@ describe('GuideLineRenderer', () => {
     expect(marks[0].tagName).toBe('MARK');
   });
 
-  it('should handle mouse events', async () => {
+  it('should handle click events', async () => {
     const user = userEvent.setup();
     render(<GuideLineRenderer {...defaultProps} />);
     
     const lineElement = screen.getByTestId('line-42');
     
-    await user.pointer({ keys: '[MouseLeft>]', target: lineElement });
-    expect(defaultProps.onMouseDown).toHaveBeenCalledWith(42);
-    
-    await user.pointer({ keys: '[/MouseLeft]', target: lineElement });
-    expect(defaultProps.onMouseUp).toHaveBeenCalled();
-    
-    await user.unhover(lineElement);
-    expect(defaultProps.onMouseLeave).toHaveBeenCalled();
+    await user.click(lineElement);
+    expect(defaultProps.onClick).toHaveBeenCalledWith(42);
   });
 
-  it('should handle touch events', async () => {
+  it('should handle touch click events', async () => {
+    const user = userEvent.setup();
     render(<GuideLineRenderer {...defaultProps} />);
     
     const lineElement = screen.getByTestId('line-42');
     
-    // Simulate touch start
-    const touchStartEvent = new TouchEvent('touchstart', {
-      bubbles: true,
-      cancelable: true,
-      touches: [{ clientX: 0, clientY: 0 } as Touch]
-    });
-    lineElement.dispatchEvent(touchStartEvent);
-    expect(defaultProps.onTouchStart).toHaveBeenCalledWith(42);
-    
-    // Simulate touch end
-    const touchEndEvent = new TouchEvent('touchend', {
-      bubbles: true,
-      cancelable: true
-    });
-    lineElement.dispatchEvent(touchEndEvent);
-    expect(defaultProps.onTouchEnd).toHaveBeenCalled();
+    // Click events work for both mouse and touch in modern browsers
+    await user.click(lineElement);
+    expect(defaultProps.onClick).toHaveBeenCalledWith(42);
   });
 
-  it('should set correct line height', () => {
-    render(<GuideLineRenderer {...defaultProps} lineHeight={32} />);
+  it('should set correct line height and font size', () => {
+    render(<GuideLineRenderer {...defaultProps} lineHeight={32} fontSize={18} />);
     
     const lineElement = screen.getByTestId('line-42');
-    expect(lineElement).toHaveStyle({ height: '32px' });
+    expect(lineElement).toHaveStyle({ height: '32px', fontSize: '18px' });
   });
 
   it('should handle empty line content', () => {

--- a/src/components/GuideLineRenderer.tsx
+++ b/src/components/GuideLineRenderer.tsx
@@ -10,11 +10,7 @@ interface GuideLineRendererProps {
   lineHeight: number;
   fontSize: number;
   searchQuery: string;
-  onMouseDown: (lineNumber: number) => void;
-  onMouseUp: () => void;
-  onMouseLeave: () => void;
-  onTouchStart: (lineNumber: number) => void;
-  onTouchEnd: () => void;
+  onClick: (lineNumber: number) => void;
 }
 
 const GuideLineRendererComponent: React.FC<GuideLineRendererProps> = ({
@@ -26,11 +22,7 @@ const GuideLineRendererComponent: React.FC<GuideLineRendererProps> = ({
   lineHeight,
   fontSize,
   searchQuery,
-  onMouseDown,
-  onMouseUp,
-  onMouseLeave,
-  onTouchStart,
-  onTouchEnd
+  onClick
 }) => {
   const highlightSearchQuery = (text: string, query: string) => {
     if (!query) return text;
@@ -66,11 +58,7 @@ const GuideLineRendererComponent: React.FC<GuideLineRendererProps> = ({
       )}
       style={{ height: `${lineHeight}px`, fontSize: `${fontSize}px` }}
       data-testid={`line-${lineNumber}`}
-      onMouseDown={() => onMouseDown(lineNumber)}
-      onMouseUp={onMouseUp}
-      onMouseLeave={onMouseLeave}
-      onTouchStart={() => onTouchStart(lineNumber)}
-      onTouchEnd={onTouchEnd}
+      onClick={() => onClick(lineNumber)}
     >
       <span className={clsx(
         // Layout

--- a/src/components/GuideReader.test.tsx
+++ b/src/components/GuideReader.test.tsx
@@ -173,8 +173,8 @@ describe('GuideReader Tests', () => {
     });
   });
 
-  describe('Tap and Hold Bookmark Feature', () => {
-    it('should show bookmark modal on long press', async () => {
+  describe('Double Tap Bookmark Feature', () => {
+    it('should show bookmark modal on double tap', async () => {
       render(
         <TestWrapper>
           <GuideReader guide={mockGuide} />
@@ -193,13 +193,9 @@ describe('GuideReader Tests', () => {
       // Find line 2 element by test id
       const lineElement = screen.getByTestId('line-2');
 
-      // Simulate mousedown
-      fireEvent.mouseDown(lineElement);
-
-      // Fast-forward timer to trigger long press (500ms + buffer)
-      act(() => {
-        jest.advanceTimersByTime(600);
-      });
+      // Simulate double tap
+      fireEvent.click(lineElement);
+      fireEvent.click(lineElement);
 
       // Wait for the modal to appear - check for the specific title
       await waitFor(() => {
@@ -233,11 +229,9 @@ describe('GuideReader Tests', () => {
       // Find line 2 element
       const lineElement = screen.getByTestId('line-2');
 
-      // Simulate long press
-      fireEvent.mouseDown(lineElement);
-      act(() => {
-        jest.advanceTimersByTime(600);
-      });
+      // Simulate double tap
+      fireEvent.click(lineElement);
+      fireEvent.click(lineElement);
 
       await waitFor(() => {
         // Check for the bookmark modal text to be displayed
@@ -279,13 +273,11 @@ describe('GuideReader Tests', () => {
         expect(screen.getByTestId('line-2')).toBeInTheDocument();
       });
 
-      // Find and long press line 2
+      // Find and double tap line 2
       const lineElement = screen.getByTestId('line-2');
 
-      fireEvent.mouseDown(lineElement);
-      act(() => {
-        jest.advanceTimersByTime(600);
-      });
+      fireEvent.click(lineElement);
+      fireEvent.click(lineElement);
 
       await waitFor(() => {
         // Check for the bookmark modal text to be displayed
@@ -363,12 +355,10 @@ describe('GuideReader Tests', () => {
         expect(screen.getByTestId('line-2')).toBeInTheDocument();
       });
 
-      // Long press to create bookmark
+      // Double tap to create bookmark
       const lineElement = screen.getByTestId('line-2');
-      fireEvent.mouseDown(lineElement);
-      act(() => {
-        jest.advanceTimersByTime(600);
-      });
+      fireEvent.click(lineElement);
+      fireEvent.click(lineElement);
 
       await waitFor(() => {
         expect(screen.getByText('Add Bookmark at Line 2')).toBeInTheDocument();
@@ -401,7 +391,7 @@ describe('GuideReader Tests', () => {
       });
     });
 
-    it('should cancel long press when mouse leaves', async () => {
+    it('should not trigger bookmark modal on single tap', async () => {
       render(
         <TestWrapper>
           <GuideReader guide={mockGuide} />
@@ -420,18 +410,10 @@ describe('GuideReader Tests', () => {
       // Find line 2 element
       const lineElement = screen.getByTestId('line-2');
 
-      // Start long press
-      fireEvent.mouseDown(lineElement);
+      // Single tap only
+      fireEvent.click(lineElement);
 
-      // Fast-forward timer partially
-      act(() => {
-        jest.advanceTimersByTime(300);
-      });
-
-      // Mouse leaves before long press completes
-      fireEvent.mouseLeave(lineElement);
-
-      // Fast-forward rest of timer
+      // Wait a bit to ensure no modal appears
       act(() => {
         jest.advanceTimersByTime(400);
       });
@@ -459,13 +441,9 @@ describe('GuideReader Tests', () => {
       // Find line 2 element
       const lineElement = screen.getByTestId('line-2');
 
-      // Simulate touch start
-      fireEvent.touchStart(lineElement);
-
-      // Fast-forward timer to trigger long press
-      act(() => {
-        jest.advanceTimersByTime(600);
-      });
+      // Simulate double tap (touch)
+      fireEvent.click(lineElement);
+      fireEvent.click(lineElement);
 
       await waitFor(() => {
         // Check for the bookmark modal text to be displayed
@@ -563,12 +541,10 @@ describe('GuideReader Tests', () => {
         expect(screen.getByTestId('line-2')).toBeInTheDocument();
       });
 
-      // Simulate long press on line 2
+      // Simulate double tap on line 2
       const lineElement = screen.getByTestId('line-2');
-      fireEvent.mouseDown(lineElement);
-      act(() => {
-        jest.advanceTimersByTime(600);
-      });
+      fireEvent.click(lineElement);
+      fireEvent.click(lineElement);
 
       await waitFor(() => {
         expect(screen.getByText('Add Bookmark at Line 2')).toBeInTheDocument();
@@ -595,12 +571,10 @@ describe('GuideReader Tests', () => {
         expect(screen.getByTestId('line-2')).toBeInTheDocument();
       });
 
-      // Open bookmark modal
+      // Open bookmark modal with double tap
       const lineElement = screen.getByTestId('line-2');
-      fireEvent.mouseDown(lineElement);
-      act(() => {
-        jest.advanceTimersByTime(600);
-      });
+      fireEvent.click(lineElement);
+      fireEvent.click(lineElement);
 
       await waitFor(() => {
         expect(screen.getByText('Add Bookmark at Line 2')).toBeInTheDocument();

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,7 +3,7 @@ export const LINE_HEIGHT = 21;
 export const MIN_LINE = 1;
 
 // Timing Constants (in milliseconds)
-export const LONGPRESS_DELAY = 500;
+export const DOUBLE_TAP_DELAY = 300;
 export const TOAST_DEFAULT_DURATION = 3000;
 export const BOOKMARK_VIBRATION_DURATION = 50;
 


### PR DESCRIPTION
- Replace 500ms long press with double tap (300ms window) to open bookmark overlay
- Update GuideLineRenderer to use single onClick handler instead of multiple mouse/touch events
- Implement double tap detection logic with line number tracking in GuideReaderView
- Update all tests to use double tap instead of long press simulation
- Update user-facing text from 'tap and hold' to 'double tap' in BookmarksEmptyState
- Maintain vibration feedback on successful double tap

Closes #67