### PR TITLE
docs: add React useEffect best practices to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,3 +115,105 @@ Based on Google TypeScript Style Guide. See `examples/` for detailed examples.
 - Follow existing test patterns for consistency
 - Mock external dependencies appropriately
 - Ensure all async operations are properly handled in tests
+
+## React Hooks Best Practices
+
+### useEffect Guidelines
+
+#### When NOT to Use useEffect
+
+**1. Transforming Data for Rendering**
+- Calculate values directly during rendering instead of using Effects
+- If something can be calculated from existing props or state, don't put it in state
+- Use `useMemo` only for expensive computations that need caching
+
+```typescript
+// ❌ Bad: Using Effect to transform data
+useEffect(() => {
+  setFullName(firstName + ' ' + lastName);
+}, [firstName, lastName]);
+
+// ✅ Good: Calculate during rendering
+const fullName = firstName + ' ' + lastName;
+```
+
+**2. Handling User Events**
+- Event-specific logic belongs in event handlers, not Effects
+- Process user interactions directly in onClick, onSubmit, etc.
+
+```typescript
+// ❌ Bad: Using Effect for event handling
+useEffect(() => {
+  if (submitted) {
+    post('/api/register', data);
+  }
+}, [submitted]);
+
+// ✅ Good: Handle in event handler
+const handleSubmit = () => {
+  post('/api/register', data);
+};
+```
+
+**3. Resetting State**
+- Use the `key` prop to reset component state
+- Calculate state directly instead of syncing with Effects
+
+```typescript
+// ❌ Bad: Using Effect to reset state
+useEffect(() => {
+  setSelection(null);
+}, [userId]);
+
+// ✅ Good: Use key prop
+<ProfilePage key={userId} />
+```
+
+#### When to Use useEffect
+
+**Proper Use Cases:**
+- Connecting to external systems (WebSocket, browser APIs, third-party libraries)
+- Setting up subscriptions and event listeners
+- Synchronizing with non-React widgets
+- Fetching data (though consider framework solutions first)
+
+```typescript
+// ✅ Good: Connecting to external system
+useEffect(() => {
+  const connection = createConnection(roomId);
+  connection.connect();
+  
+  return () => {
+    connection.disconnect();
+  };
+}, [roomId]);
+```
+
+#### Common Anti-Patterns to Avoid
+
+1. **Chains of Effects** - Avoid Effects that trigger other Effects
+2. **Missing Dependencies** - Always include all dependencies
+3. **Suppressing Linter Warnings** - Fix the root cause instead
+4. **Not Implementing Cleanup** - Always clean up subscriptions and connections
+
+#### Best Practices
+
+1. **Think of Effects as Independent Processes**
+   - Each Effect should handle one concern
+   - Design around a single setup/cleanup cycle
+
+2. **Effects Run Multiple Times**
+   - Make Effects resilient to re-execution
+   - Don't assume they run only once
+
+3. **Prefer Alternatives**
+   - Event handlers for user interactions
+   - Direct calculations during rendering
+   - Framework-specific data fetching solutions
+   - Custom Hooks for reusable logic
+
+4. **Keep Effects Simple**
+   - If an Effect does too much, split it
+   - Extract complex logic into functions
+
+Remember: **"If you're not trying to synchronize with some external system, you probably don't need an Effect."**


### PR DESCRIPTION
## Summary
- Added comprehensive React Hooks Best Practices section to CLAUDE.md
- Documented when NOT to use useEffect based on React documentation
- Included proper use cases and common anti-patterns

## Details
This PR addresses issue #82 by adding useEffect best practices learned from the official React documentation. The new section includes:

1. **When NOT to use useEffect:**
   - Transforming data for rendering
   - Handling user events
   - Resetting state

2. **When to use useEffect:**
   - Connecting to external systems
   - Setting up subscriptions
   - Synchronizing with non-React widgets

3. **Common anti-patterns to avoid**

4. **Best practices and alternatives**

Each guideline includes code examples showing both bad and good approaches.

## Test Plan
- [x] Documentation only change - no source code modifications
- [x] Lint passes
- [x] Reviewed React official documentation at https://react.dev/reference/react/useEffect

Closes #82